### PR TITLE
Parsing non-standard effects

### DIFF
--- a/dist/ass-compiler.js
+++ b/dist/ass-compiler.js
@@ -26,9 +26,6 @@
         fadeAwayHeight: param[4] * 1 || 0,
       };
     }
-    if (text !== '') {
-      return text;
-    }
     return null;
   }
 

--- a/dist/ass-compiler.js
+++ b/dist/ass-compiler.js
@@ -26,6 +26,9 @@
         fadeAwayHeight: param[4] * 1 || 0,
       };
     }
+    if (text !== '') {
+      return text;
+    }
     return null;
   }
 

--- a/src/parser/effect.js
+++ b/src/parser/effect.js
@@ -21,7 +21,7 @@ export function parseEffect(text) {
     };
   }
   if (text !== '') {
-    return text;
+    return { name: text };
   }
   return null;
 }

--- a/src/parser/effect.js
+++ b/src/parser/effect.js
@@ -20,5 +20,8 @@ export function parseEffect(text) {
       fadeAwayHeight: param[4] * 1 || 0,
     };
   }
+  if (text !== '') {
+    return text;
+  }
   return null;
 }

--- a/src/stringifier.js
+++ b/src/stringifier.js
@@ -16,13 +16,13 @@ export function stringifyTime(t) {
 
 export function stringifyEffect(eff) {
   if (!eff) return '';
-  if (typeof eff === 'string') {
-    return eff;
-  }
   if (eff.name === 'banner') {
     return `Banner;${eff.delay};${eff.leftToRight};${eff.fadeAwayWidth}`;
   }
-  return `${eff.name.replace(/^\w/, (x) => x.toUpperCase())};${eff.y1};${eff.y2};${eff.delay};${eff.fadeAwayHeight}`;
+  if (/^scroll\s/.test(eff.name)) {
+    return `${eff.name.replace(/^\w/, (x) => x.toUpperCase())};${eff.y1};${eff.y2};${eff.delay};${eff.fadeAwayHeight}`;
+  }
+  return eff.name;
 }
 
 export function stringifyDrawing(drawing) {

--- a/src/stringifier.js
+++ b/src/stringifier.js
@@ -16,6 +16,9 @@ export function stringifyTime(t) {
 
 export function stringifyEffect(eff) {
   if (!eff) return '';
+  if (typeof eff === 'string') {
+    return eff;
+  }
   if (eff.name === 'banner') {
     return `Banner;${eff.delay};${eff.leftToRight};${eff.fadeAwayWidth}`;
   }

--- a/test/parser/effect.js
+++ b/test/parser/effect.js
@@ -73,7 +73,11 @@ describe('effect parser', () => {
     });
   });
 
-  it('should ignore wrong syntax', () => {
-    expect(parseEffect('unknown')).to.equal(null);
+  it('should return exact copy if non-standard, but non empty', () => {
+    expect(parseEffect('unknown')).to.equal('unknown');
+  });
+
+  it('should return null if empty', () => {
+    expect(parseEffect('')).to.equal(null);
   });
 });

--- a/test/parser/effect.js
+++ b/test/parser/effect.js
@@ -73,8 +73,8 @@ describe('effect parser', () => {
     });
   });
 
-  it('should return exact copy if non-standard, but non empty', () => {
-    expect(parseEffect('unknown')).to.equal('unknown');
+  it('should return EffectUnknown if non-standard, but non empty', () => {
+    expect(parseEffect('unknown')).to.deep.equal({ name: 'unknown' });
   });
 
   it('should return null if empty', () => {

--- a/test/stringifier.js
+++ b/test/stringifier.js
@@ -30,6 +30,9 @@ describe('ASS stringifier', () => {
       leftToRight: 1,
       fadeAwayWidth: 80,
     })).to.equal('Banner;5;1;80');
+    expect(stringifyEffect({
+      name: 'unknown',
+    })).to.equal('unknown');
   });
 
   it('should stringify event', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -61,6 +61,10 @@ interface EffectScroll {
     fadeAwayHeight: number;
 }
 
+interface EffectUnknown {
+    name: string;
+}
+
 interface ParsedASSEventText {
     raw: string;
     combined: string;
@@ -76,7 +80,7 @@ interface ParsedASSEvent {
     MarginL: number;
     MarginR: number;
     MarginV: number;
-    Effect?: EffectBanner | EffectScroll | string;
+    Effect?: EffectBanner | EffectScroll | EffectUnknown;
     Text: ParsedASSEventText;
 }
 
@@ -195,7 +199,7 @@ export interface Dialogue {
         right: number;
         vertical: number;
     }
-    effect?: EffectBanner | EffectScroll;
+    effect?: EffectBanner | EffectScroll | EffectUnknown;
     alignment: number;
     slices: DialogueSlice[];
     pos?: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -76,7 +76,7 @@ interface ParsedASSEvent {
     MarginL: number;
     MarginR: number;
     MarginV: number;
-    Effect?: EffectBanner | EffectScroll;
+    Effect?: EffectBanner | EffectScroll | string;
     Text: ParsedASSEventText;
 }
 


### PR DESCRIPTION
This makes it so that if the parser must handle a non-standard value in the Effect field it return a string in the tree.
For reasons stated in #12, this would be useful.